### PR TITLE
Fix PUT

### DIFF
--- a/src/main/java/com/sst/nt/lms/orch/controller/ExecutiveController.java
+++ b/src/main/java/com/sst/nt/lms/orch/controller/ExecutiveController.java
@@ -182,6 +182,7 @@ public final class ExecutiveController {
 			@PathVariable("branchId") final int branchId,
 			@PathVariable("borrowerId") final int borrowerId,
 			@RequestParam @DateTimeFormat(iso = ISO.DATE) final LocalDate dueDate) {
+		// TODO: dueDate should be @RequestBody, and passed that way to admin, not @RequestParam
 		return delegate.exchange(
 				"http://admin/loan/book/" + bookId + "/branch/" + branchId
 						+ "/borrower/" + borrowerId + "/due",

--- a/src/main/java/com/sst/nt/lms/orch/controller/LibrarianController.java
+++ b/src/main/java/com/sst/nt/lms/orch/controller/LibrarianController.java
@@ -78,7 +78,7 @@ public class LibrarianController {
 			"/branch/{branchId}/book/{bookId}/" }, method = RequestMethod.PUT)
 	public ResponseEntity<BranchCopies> setBranchCopies(@PathVariable("branchId") int branchId,
 			@PathVariable("bookId") int bookId, @RequestParam("noOfCopies") int copies) {
-
+		// TODO: copies should be @RequestBody, and passed that way to librarian-service, not @RequestParam
 		return this.<BranchCopies> doProcess(
 				"http://librarian-service/librarian/branches/" + branchId + "/books/" + bookId + "?noOfCopies=" + copies,
 				HttpMethod.PUT);

--- a/src/main/java/com/sst/nt/lms/orch/controller/LibrarianController.java
+++ b/src/main/java/com/sst/nt/lms/orch/controller/LibrarianController.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -69,8 +70,8 @@ public class LibrarianController {
 	@RequestMapping(path = { "/branches/{branchId}", "/branches/{branchId}/" }, method = RequestMethod.PUT)
 	public ResponseEntity<Branch> updateBranch(@PathVariable("branchId") final int branchId,
 			@RequestBody Branch input) {
-
-		return this.<Branch> doProcess("http://librarian-service/librarian/branches/" + branchId, HttpMethod.PUT);
+		return restTemplate.exchange("http://librarian-service/librarian/branches/" + branchId,
+				HttpMethod.PUT, new HttpEntity<>(input), Branch.class);
 
 	}
 


### PR DESCRIPTION
`PUT` methods were much less trouble than `POST` (those were fixed in #10). It turns out that they fall into three categories:

- Should already work properly; the only possible cause of trouble might be missing HTTP headers.
- Appear to work, but follow an anti-pattern (*expect* their `PUT` arguments as query parameters, and call the microservices with a URL constructed to include a query string)
- Take their parameters as `@RequestBody` already, but don't pass them to the microservices

This PR adds `TODO` comments to the second class, and fixes the sole instance of the third. If there's actual trouble with methods in the first class, I can make another commit to add the required `Content-Type` header in those methods.