### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud.version>Greenwich.SR1</spring-cloud.version>
+		<!-- <jackson.version>2.9.9.1</jackson.version --> <!-- Uncomment as soon as FasterXML/jackson-bom#22 merged -->
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.7.RELEASE</version>
+		<version>2.1.8.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sst.nt.lms</groupId>
@@ -16,8 +16,8 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
-		<jackson.version>2.9.9.20190807</jackson.version>
+		<spring-cloud.version>Greenwich.SR3</spring-cloud.version>
+		<jackson.version>2.9.10</jackson.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Greenwich.SR1</spring-cloud.version>
+		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
 		<!-- <jackson.version>2.9.9.1</jackson.version --> <!-- Uncomment as soon as FasterXML/jackson-bom#22 merged -->
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.6.RELEASE</version>
+		<version>2.1.7.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sst.nt.lms</groupId>
@@ -17,7 +17,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
-		<!-- <jackson.version>2.9.9.1</jackson.version --> <!-- Uncomment as soon as FasterXML/jackson-bom#22 merged -->
+		<jackson.version>2.9.9.20190807</jackson.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
The core Spring dependencies were already at the version that is currently the latest, but the "Spring Cloud" version specified is not, and there's a Jackson version bump that's been released but hasn't made its way into a form we can depend on yet (FasterXML/jackson-bom#22).

I'll be merging this into my fork's `master` branch at once, but wanted to push it "upstream" as a PR as well.